### PR TITLE
Fixed several deletion blockers

### DIFF
--- a/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/ui/struts/action/FenixEduGiafContractsContextListener.java
+++ b/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/ui/struts/action/FenixEduGiafContractsContextListener.java
@@ -49,7 +49,7 @@ public class FenixEduGiafContractsContextListener implements ServletContextListe
                     if (person.getEmployee() != null) {
                         blockers.add(BundleUtil.getString(Bundle.APPLICATION, "error.person.cannot.be.deleted"));
                     }
-                    if (((Collection<PersonFunction>) person.getParentAccountabilities(
+                    if (!((Collection<PersonFunction>) person.getParentAccountabilities(
                             AccountabilityTypeEnum.MANAGEMENT_FUNCTION, PersonFunction.class)).isEmpty()) {
                         blockers.add(BundleUtil.getString(Bundle.APPLICATION, "error.person.cannot.be.deleted"));
                     }
@@ -60,7 +60,7 @@ public class FenixEduGiafContractsContextListener implements ServletContextListe
             }
         });
         FenixFramework.getDomainModel().registerDeletionBlockerListener(Unit.class, (unit, blockers) -> {
-            if (unit.getFunctionsSet().isEmpty()) {
+            if (!unit.getFunctionsSet().isEmpty()) {
                 blockers.add(BundleUtil.getString(Bundle.APPLICATION, "error.unit.cannot.be.deleted"));
             }
         });

--- a/fenixedu-ist-pre-bolonha/src/main/java/org/fenixedu/academic/ui/struts/action/FenixEduPreBolonhaContextListener.java
+++ b/fenixedu-ist-pre-bolonha/src/main/java/org/fenixedu/academic/ui/struts/action/FenixEduPreBolonhaContextListener.java
@@ -35,12 +35,12 @@ public class FenixEduPreBolonhaContextListener implements ServletContextListener
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         FenixFramework.getDomainModel().registerDeletionBlockerListener(ExecutionDegree.class, (executionDegree, blockers) -> {
-            if (executionDegree.getMasterDegreeCandidatesSet().isEmpty()) {
+            if (!executionDegree.getMasterDegreeCandidatesSet().isEmpty()) {
                 blockers.add(BundleUtil.getString(Bundle.APPLICATION, "execution.degree.cannot.be.deleted"));
             }
         });
         FenixFramework.getDomainModel().registerDeletionBlockerListener(Person.class, (person, blockers) -> {
-            if (person.getMasterDegreeCandidatesSet().isEmpty()) {
+            if (!person.getMasterDegreeCandidatesSet().isEmpty()) {
                 blockers.add(BundleUtil.getString(Bundle.APPLICATION, "error.person.cannot.be.deleted"));
             }
         });


### PR DESCRIPTION
Some deletion blockers were halting the deletion if there were no
connections, instead of doing so if the object was still connected.
This commit fixes that by inverting the test condition.