### PR TITLE
Changed group presentation names to be more uniform and readable FIST-86 #resolve

### DIFF
--- a/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/domain/accessControl/ActiveEmployees.java
+++ b/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/domain/accessControl/ActiveEmployees.java
@@ -21,10 +21,12 @@ package pt.ist.fenixedu.contracts.domain.accessControl;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.fenixedu.academic.util.Bundle;
 import org.fenixedu.bennu.core.annotation.GroupOperator;
 import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.GroupStrategy;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.joda.time.DateTime;
 
 import pt.ist.fenixedu.contracts.domain.Employee;
@@ -36,7 +38,7 @@ public class ActiveEmployees extends GroupStrategy {
 
     @Override
     public String getPresentationName() {
-        return "Active Employees";
+        return BundleUtil.getString(Bundle.GROUP, "label.name.ActiveEmployeesGroup");
     }
 
     @Override

--- a/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/domain/accessControl/ActiveGrantOwner.java
+++ b/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/domain/accessControl/ActiveGrantOwner.java
@@ -21,10 +21,12 @@ package pt.ist.fenixedu.contracts.domain.accessControl;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.fenixedu.academic.util.Bundle;
 import org.fenixedu.bennu.core.annotation.GroupOperator;
 import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.GroupStrategy;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.joda.time.DateTime;
 
 import pt.ist.fenixedu.contracts.domain.Employee;
@@ -36,7 +38,7 @@ public class ActiveGrantOwner extends GroupStrategy {
 
     @Override
     public String getPresentationName() {
-        return "Active Grant Owner";
+        return BundleUtil.getString(Bundle.GROUP, "label.name.ActiveGrantOwnersGroup");
     }
 
     @Override

--- a/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/domain/accessControl/ActiveResearchers.java
+++ b/fenixedu-ist-giaf-contracts/src/main/java/pt/ist/fenixedu/contracts/domain/accessControl/ActiveResearchers.java
@@ -21,6 +21,8 @@ package pt.ist.fenixedu.contracts.domain.accessControl;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.fenixedu.academic.util.Bundle;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.fenixedu.bennu.core.annotation.GroupOperator;
 import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.bennu.core.domain.User;
@@ -36,7 +38,7 @@ public class ActiveResearchers extends GroupStrategy {
 
     @Override
     public String getPresentationName() {
-        return "Active Researchers";
+        return BundleUtil.getString(Bundle.GROUP, "label.name.ActiveResearchersGroup");
     }
 
     @Override

--- a/fenixedu-ist-teacher-credits/src/main/java/pt/ist/fenixedu/teacher/domain/CreditsManagerGroup.java
+++ b/fenixedu-ist-teacher-credits/src/main/java/pt/ist/fenixedu/teacher/domain/CreditsManagerGroup.java
@@ -23,10 +23,12 @@ import java.util.Set;
 
 import org.fenixedu.academic.domain.Department;
 import org.fenixedu.academic.domain.Person;
+import org.fenixedu.academic.util.Bundle;
 import org.fenixedu.bennu.core.annotation.GroupOperator;
 import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.GroupStrategy;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.joda.time.DateTime;
 
 @GroupOperator("creditsManager")
@@ -34,7 +36,7 @@ public class CreditsManagerGroup extends GroupStrategy {
 
     @Override
     public String getPresentationName() {
-        return "Credits Manager";
+        return BundleUtil.getString(Bundle.TEACHER_CREDITS, "label.group.CreditsManagerGroup");
     }
 
     @Override

--- a/fenixedu-ist-vigilancies/src/main/java/pt/ist/fenixedu/vigilancies/domain/accessControl/ExamCoordinatorGroup.java
+++ b/fenixedu-ist-vigilancies/src/main/java/pt/ist/fenixedu/vigilancies/domain/accessControl/ExamCoordinatorGroup.java
@@ -22,10 +22,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.fenixedu.academic.domain.ExecutionYear;
+import org.fenixedu.academic.util.Bundle;
 import org.fenixedu.bennu.core.annotation.GroupOperator;
 import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.GroupStrategy;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.joda.time.DateTime;
 
 @GroupOperator("examCoordinator")
@@ -35,7 +37,7 @@ public class ExamCoordinatorGroup extends GroupStrategy {
 
     @Override
     public String getPresentationName() {
-        return "Exam Coordinator";
+        return BundleUtil.getString("resources.VigilancyResources", "label.group.name.ExamCoordinatorGroup");
     }
 
     @Override

--- a/fenixedu-ist-vigilancies/src/main/resources/resources/VigilancyResources_en.properties
+++ b/fenixedu-ist-vigilancies/src/main/resources/resources/VigilancyResources_en.properties
@@ -23,6 +23,7 @@ label.estimatedPoints = Dear Points
 label.evaluationAfterDate = The assessment date has passed
 label.exportGroupReport = Export data
 label.generateStats = Generate Report
+label.group.ExamCoordinatorGroup = Exam Coordinators
 label.manage = Manage
 label.navheader.person.examCoordinator = Exam Coordination
 label.navheader.person.vigilant = Vigilancy

--- a/fenixedu-ist-vigilancies/src/main/resources/resources/VigilancyResources_pt.properties
+++ b/fenixedu-ist-vigilancies/src/main/resources/resources/VigilancyResources_pt.properties
@@ -23,6 +23,7 @@ label.estimatedPoints = Pontos Estimados
 label.evaluationAfterDate = A avaliação já passou da data
 label.exportGroupReport = Exportar dados
 label.generateStats = Gerar relatório
+label.group.ExamCoordinatorGroup = Coordenação de Exames
 label.manage = Gerir
 label.navheader.person.examCoordinator = Coordenação de Exames
 label.navheader.person.vigilant = Vigilâncias


### PR DESCRIPTION
All groups now have a localizable names. Some properties for group names still
remain in the Academic bundles.

Related Jira Issues: ACDM-715, FIST-86