### PR TITLE
#resolves FIST-113 - Export cost center codes as padded strings

### DIFF
--- a/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/task/exportData/humanResources/ExportEmployeeInfo.java
+++ b/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/task/exportData/humanResources/ExportEmployeeInfo.java
@@ -4,6 +4,7 @@ import java.io.FileOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.apache.commons.lang.StringUtils;
 import org.fenixedu.academic.domain.Person;
 import org.fenixedu.academic.domain.Teacher;
 import org.fenixedu.academic.domain.TeacherAuthorization;
@@ -98,7 +99,7 @@ public class ExportEmployeeInfo extends CustomTask {
         final JsonObject object = new JsonObject();
         object.addProperty("user", user.getUsername());
         object.addProperty("role", type.name());
-        object.addProperty("wp", wp);
+        object.addProperty("wp", StringUtils.leftPad(wp, 4, '0'));
         object.addProperty("employer", employer);
         result.add(object);
     }


### PR DESCRIPTION
When exporting cost center codes as strings, the number needs to be left padded with zeroes to 4 digits. #resolves FIST-113