### PR TITLE
Fix QUC delegate access FIST-191 #resolve

### DIFF
--- a/fenixedu-ist-quc/src/main/java/pt/ist/fenixedu/quc/domain/DelegateInquiryTemplate.java
+++ b/fenixedu-ist-quc/src/main/java/pt/ist/fenixedu/quc/domain/DelegateInquiryTemplate.java
@@ -99,9 +99,9 @@ public class DelegateInquiryTemplate extends DelegateInquiryTemplate_Base {
         }
 
         final ExecutionDegree executionDegree =
-                ExecutionDegree.getByDegreeCurricularPlanAndExecutionYear(yearDelegate.getRegistration()
-                        .getStudentCurricularPlan(executionSemester).getDegreeCurricularPlan(),
-                        executionSemester.getExecutionYear());
+                yearDelegate.getDegree().getExecutionDegreesForExecutionYear(executionSemester.getExecutionYear()).stream()
+                        .findFirst().orElse(null);
+
         for (ExecutionCourse executionCourse : DelegateUtils.getExecutionCoursesToInquiries(yearDelegate, executionSemester,
                 executionDegree)) {
             if (hasMandatoryCommentsToMake(yearDelegate, executionCourse, executionDegree)) {

--- a/fenixedu-ist-quc/src/main/java/pt/ist/fenixedu/quc/ui/struts/action/delegate/YearDelegateInquiryDA.java
+++ b/fenixedu-ist-quc/src/main/java/pt/ist/fenixedu/quc/ui/struts/action/delegate/YearDelegateInquiryDA.java
@@ -100,10 +100,8 @@ public class YearDelegateInquiryDA extends FenixDispatchAction {
             }
 
             final ExecutionDegree executionDegree =
-
-                    ExecutionDegree.getByDegreeCurricularPlanAndExecutionYear(yearDelegate.getRegistration()
-                            .getStudentCurricularPlan(executionPeriod).getDegreeCurricularPlan(),
-                            executionPeriod.getExecutionYear());
+                    yearDelegate.getDegree().getExecutionDegreesForExecutionYear(executionPeriod.getExecutionYear()).stream()
+                            .findFirst().orElse(null);
 
             Set<ExecutionCourse> executionCoursesToInquiries =
                     DelegateUtils.getExecutionCoursesToInquiries(yearDelegate, executionPeriod, executionDegree);


### PR DESCRIPTION
the registration of the delegate can not be used to get the execution degree since the delegate can be in another degree of the one which he is delegate