### PR TITLE
Limit observation to 80 characters. FIST-223 #resolve

### DIFF
--- a/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/Utils.java
+++ b/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/Utils.java
@@ -711,11 +711,16 @@ public class Utils {
                 }
                 builder.append(exemption.getDescription().toString());
             }
-            e.addProperty("observation", builder.toString());
+            e.addProperty("observation", max80(builder.toString()));
             a.add(e);
         }
         o.add("entries", a);
         return o;
+    }
+
+    private static String max80(final String s) {
+        final int l = s.length();
+        return l > 80 ? s.substring(0, 80) : s;
     }
 
     public static Money discountsAndExcemptions(final Event event) {


### PR DESCRIPTION
When registering a discount or an exemption if GIAF, the observation field must be limited to 80 characters.