### PR TITLE
Send academic year information when creating invoices. FIST-237 #resolve

### DIFF
--- a/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/Utils.java
+++ b/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/Utils.java
@@ -319,7 +319,7 @@ public class Utils {
             e.addProperty("legalArticle", "M99");
             e.addProperty("rubrica", rubrica);
             e.addProperty("observation", "");
-            o.addProperty("reference", debtYear.getName());
+            e.addProperty("reference", debtYear.getName());
             a.add(e);
         }
         o.add("entries", a);
@@ -387,7 +387,7 @@ public class Utils {
             e.addProperty("legalArticle", "M99");
             e.addProperty("rubrica", rubrica);
             e.addProperty("observation", "");
-            o.addProperty("reference", debtYear.getName());
+            e.addProperty("reference", debtYear.getName());
             a.add(e);
         }
         o.add("entries", a);
@@ -556,7 +556,7 @@ public class Utils {
             e.addProperty("legalArticle", "M99");
             e.addProperty("rubrica", invoiceId == null || invoiceId.trim().isEmpty() || rubrica == null ? "" : rubrica);
             e.addProperty("observation", "");
-            o.addProperty("reference", debtYear.getName());
+            e.addProperty("reference", debtYear.getName());
             a.add(e);
         }
         o.add("entries", a);
@@ -629,7 +629,7 @@ public class Utils {
             e.addProperty("legalArticle", "M99");
             e.addProperty("rubrica", invoiceId == null || invoiceId.trim().isEmpty() || rubrica == null ? "" : rubrica);
             e.addProperty("observation", "");
-            o.addProperty("reference", debtYear.getName());
+            e.addProperty("reference", debtYear.getName());
             a.add(e);
         }
         o.add("entries", a);


### PR DESCRIPTION
When creating an invoice in GIAF, the corresponding academic year must be filled in so that the debt can be correctly aggregated in the financial system. This information is not being sent. The bug was a set property that was being called on the wrong json object.