### PR TITLE
Wrong value is being calculated for excemptions. FIST-243 #resolve

### DIFF
--- a/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/Utils.java
+++ b/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/Utils.java
@@ -95,11 +95,11 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.YearMonthDay;
 
-import pt.ist.fenixframework.DomainObject;
-
 import com.google.common.base.CharMatcher;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
+import pt.ist.fenixframework.DomainObject;
 
 public class Utils {
 
@@ -427,7 +427,7 @@ public class Utils {
     }
 
     private static Money amountFor(final Event event, final Exemption e) {
-        final Money amount = event.getOriginalAmountToPay();
+        final Money amount = calculateTotalDebtValue(event);
         if (e instanceof AcademicEventExemption) {
             final AcademicEventExemption o = (AcademicEventExemption) e;
             return o.getValue();


### PR DESCRIPTION
When calculating the value of an exemption, it must be compared to the original value of the debt event, and not take into account existing exemptions.