### PR TITLE
showing exams information should always check for the exam map state FIST-298 #resolve

### DIFF
--- a/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/api/FenixAPIv1.java
+++ b/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/api/FenixAPIv1.java
@@ -758,6 +758,12 @@ public class FenixAPIv1 {
         }
 
         for (ExecutionCourse executionCourse : executionCourses) {
+            if (evaluation instanceof Exam) {
+                Exam exam = (Exam) evaluation;
+                if (!exam.isExamsMapPublished()) {
+                    continue;
+                }
+            }
             evaluations.add(getWrittenEvaluationJSON((WrittenEvaluation) evaluation, executionCourse, isEnrolled, student));
         }
         return evaluations;


### PR DESCRIPTION
This commit is only part of the resolution.