### PR TITLE
Use Zero Value for cancelled events. FIST-307 #resolve

### DIFF
--- a/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/EventWrapper.java
+++ b/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/EventWrapper.java
@@ -47,7 +47,7 @@ public class EventWrapper {
 
         // calculate debt
         {
-            final Money value = calculateTotalDebtValue();
+            final Money value = event.isCancelled() ? Money.ZERO : calculateTotalDebtValue();
             final Money diff = value.subtract(payedBeforThreshold);
             debt = diff.isPositive() ? diff : Money.ZERO;
         }


### PR DESCRIPTION
When syncing debt information to GIAF, the debt value for a cancelled event should be set to ZERO