### PR TITLE
Fix broken links in the ashes-ist theme. FIST-326 #resolve

### DIFF
--- a/fenixedu-ist-integration/src/main/webapp/themes/ashes-ist/public.html
+++ b/fenixedu-ist-integration/src/main/webapp/themes/ashes-ist/public.html
@@ -123,23 +123,20 @@
 		<div class="row perf_nav hidden-xs">
 			<ul class="col-sm-10 col-sm-offset-2">
 				<li><a href="https://tecnico.ulisboa.pt/">{{i18n('resources.GlobalResources', 'link.home')}}</a></li>
-			  	<li><a href="https://tecnico.ulisboa.pt/pt/alunos/">{{i18n('resources.GlobalResources', 'link.student')}}</a></li>
-			  	<li><a href="https://tecnico.ulisboa.pt/pt/docentes/">{{i18n('resources.GlobalResources', 'link.teacher')}}</a></li>
-				<li><a href="https://tecnico.ulisboa.pt/pt/pessoal/">{{i18n('resources.GlobalResources', 'link.staff')}}</a></li>
-				<li><a href="https://tecnico.ulisboa.pt/pt/candidatos/">{{i18n('resources.GlobalResources', 'link.candidade')}}	</a></li>	
+				<li><a href="https://tecnico.ulisboa.pt/pt/ensino/estudar-no-tecnico/candidaturas-e-inscricoes/">{{i18n('resources.GlobalResources', 'link.candidade')}}	</a></li>
 			  	<li><a href="https://tecnico.ulisboa.pt/en/">{{i18n('resources.GlobalResources', 'link.international')}}</a></li>
-			  	<li><a href="https://tecnico.ulisboa.pt/pt/alumni/">{{i18n('resources.GlobalResources', 'link.alumni')}}</a></li>
+			  	<li><a href="https://tecnico.ulisboa.pt/pt/alumni-e-parceiros/alumni/">{{i18n('resources.GlobalResources', 'link.alumni')}}</a></li>
 			</ul>
 		</div>
 
 		<div class="row main-row">
 			<nav class="col-sm-2 hidden-xs" id="context">
 				<ul>
-					<li><a href="http://tecnico.ulisboa.pt/html/instituto/">{{i18n('resources.GlobalResources', 'label.institution')}}</a></li>
-					<li><a href="http://tecnico.ulisboa.pt/html/estrutura/">{{i18n('resources.GlobalResources', 'label.structure')}}</a></li>
-					<li><a href="http://tecnico.ulisboa.pt/html/ensino/">{{i18n('resources.GlobalResources', 'label.education')}}</a></li>
-					<li><a href="http://tecnico.ulisboa.pt/html/id/">{{i18n('resources.GlobalResources', 'label.research.and.development.acronyms')}}</a></li>
-					<li><a href="http://tecnico.ulisboa.pt/html/viverist/">Viver no Técnico Lisboa</a></li>
+					<li><a href="https://tecnico.ulisboa.pt/pt/sobre-o-tecnico/">{{i18n('resources.GlobalResources', 'label.institution')}}</a></li>
+					<li><a href="https://tecnico.ulisboa.pt/pt/sobre-o-tecnico/institucional/organizacao/">{{i18n('resources.GlobalResources', 'label.structure')}}</a></li>
+					<li><a href="https://tecnico.ulisboa.pt/pt/ensino/">{{i18n('resources.GlobalResources', 'label.education')}}</a></li>
+					<li><a href="https://tecnico.ulisboa.pt/pt/investigacao-e-inovacao/id/">{{i18n('resources.GlobalResources', 'label.research.and.development.acronyms')}}</a></li>
+					<li><a href="https://tecnico.ulisboa.pt/pt/viver/">Viver no Técnico Lisboa</a></li>
 				</ul>
 			</nav>
 			<main class="col-sm-10" role="main">
@@ -157,7 +154,7 @@
 		<footer class="row">
 			<div class="col-sm-12">
 				<span class="pull-left">
-					<a href="http://tecnico.ulisboa.pt/pt/sobre-IST/contactos/">
+					<a href="https://tecnico.ulisboa.pt/pt/contactos/">
 						{{i18n('resources.GlobalResources', 'footer.contacts.label')}}
 					</a>
 					|


### PR DESCRIPTION
Fixes some broken links which pointed to the previous IST website.
The 'Student', 'Teacher' and 'Staff' entries don't seem to have a direct correspondence to the new website and have thus been removed.