### PR TITLE
Avoid catching domain exceptions in transactions. FIST-445 #resolve

### DIFF
--- a/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/task/updateData/student/CreateGratuityEvents.java
+++ b/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/task/updateData/student/CreateGratuityEvents.java
@@ -66,21 +66,24 @@ public class CreateGratuityEvents extends CronTask {
         generateGratuityEvent(studentCurricularPlan, executionYear);
     }
 
-    @Atomic(mode = TxMode.WRITE)
     private void generateGratuityEvent(StudentCurricularPlan studentCurricularPlan, ExecutionYear executionYear) {
         try {
-            final AccountingEventsManager manager = new AccountingEventsManager();
-
-            final InvocationResult result = manager.createGratuityEvent(studentCurricularPlan, executionYear);
-
-            if (result.isSuccess()) {
-                GratuityEvent_TOTAL_CREATED++;
-            }
+            generateGratuityEventAtomic(executionYear, studentCurricularPlan);
         } catch (Exception e) {
             taskLog("Exception on student curricular plan with oid : %s\n", studentCurricularPlan.getExternalId());
             StringWriter writer = new StringWriter();
             e.printStackTrace(new PrintWriter(writer));
             taskLog(writer.toString());
+        }
+
+    }
+
+    @Atomic(mode = TxMode.WRITE)
+    private void generateGratuityEventAtomic(ExecutionYear executionYear, StudentCurricularPlan studentCurricularPlan) {
+        final AccountingEventsManager manager = new AccountingEventsManager();
+        final InvocationResult result = manager.createGratuityEvent(studentCurricularPlan, executionYear);
+        if (result.isSuccess()) {
+            GratuityEvent_TOTAL_CREATED++;
         }
     }
 

--- a/fenixedu-ist-vigilancies/src/main/java/pt/ist/fenixedu/vigilancies/service/AddExecutionCourseToGroup.java
+++ b/fenixedu-ist-vigilancies/src/main/java/pt/ist/fenixedu/vigilancies/service/AddExecutionCourseToGroup.java
@@ -29,19 +29,22 @@ import pt.ist.fenixframework.Atomic;
 
 public class AddExecutionCourseToGroup {
 
-    @Atomic
     public static List<ExecutionCourse> run(VigilantGroup group, List<ExecutionCourse> executionCourses) {
 
         List<ExecutionCourse> executionCoursesUnableToAdd = new ArrayList<ExecutionCourse>();
         for (ExecutionCourse course : executionCourses) {
             try {
-                group.addExecutionCourses(course);
-
+                runAtomic(group, course);
             } catch (DomainException e) {
                 executionCoursesUnableToAdd.add(course);
             }
         }
         return executionCoursesUnableToAdd;
+    }
+
+    @Atomic
+    private static void runAtomic(VigilantGroup group, ExecutionCourse course) {
+        group.addExecutionCourses(course);
     }
 
 }

--- a/fenixedu-ist-vigilancies/src/main/java/pt/ist/fenixedu/vigilancies/service/RemoveVigilantsFromGroup.java
+++ b/fenixedu-ist-vigilancies/src/main/java/pt/ist/fenixedu/vigilancies/service/RemoveVigilantsFromGroup.java
@@ -31,7 +31,6 @@ import pt.ist.fenixframework.Atomic;
 
 public class RemoveVigilantsFromGroup {
 
-    @Atomic
     public static List<VigilantWrapper> run(Map<VigilantGroup, List<VigilantWrapper>> vigilantsToRemove) {
 
         List<VigilantWrapper> unableToRemove = new ArrayList<VigilantWrapper>();
@@ -43,12 +42,17 @@ public class RemoveVigilantsFromGroup {
 
             for (VigilantWrapper vigilantWrapper : vigilantWrappers) {
                 try {
-                    vigilantWrapper.delete();
+                    runAtomic(vigilantWrapper);
                 } catch (DomainException e) {
                     unableToRemove.add(vigilantWrapper);
                 }
             }
         }
         return unableToRemove;
+    }
+
+    @Atomic
+    private static void runAtomic(VigilantWrapper vigilantWrapper) {
+        vigilantWrapper.delete();
     }
 }


### PR DESCRIPTION
Remove the catches of domain exceptions from transactions. The transaction code is moved to a auxiliar method which is made atomic.