### PR TITLE
Hack invocie dates to last date of previous year. FIST-522 #resolve

### DIFF
--- a/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/GiafEvent.java
+++ b/fenixedu-ist-giaf-invoices/src/main/java/pt/ist/fenixedu/giaf/invoices/GiafEvent.java
@@ -389,7 +389,7 @@ public class GiafEvent {
         if (invoiceId != null) {
             o.addProperty("invoiceId", invoiceId);
         }
-        o.addProperty("date", toString(new Date()));
+        o.addProperty("date", toString(new Date(2017, 12, 31, 0, 0, 0)));
         o.addProperty("type", type);
         o.addProperty("series", "13");
         o.addProperty("group", "212");


### PR DESCRIPTION
Hack invocie dates to last date of previous year, so that academic services can process stuff retroactively.