### PR TITLE
Changing permission of Page item does not update its children Page items FIST-515 #resolve

### DIFF
--- a/fenixedu-ist-cms-components/src/main/java/pt/ist/fenixedu/cmscomponents/ui/spring/PagesAdminService.java
+++ b/fenixedu-ist-cms-components/src/main/java/pt/ist/fenixedu/cmscomponents/ui/spring/PagesAdminService.java
@@ -149,6 +149,7 @@ public class PagesAdminService {
 
         if (canViewGroup != null && !post.getCanViewGroup().equals(canViewGroup)) {
             post.setCanViewGroup(canViewGroup);
+            menuItem.getChildrenSorted().stream().filter(isStaticPage).forEach(subitem -> postForPage(subitem.getPage()).setCanViewGroup(canViewGroup));
         }
 
         return menuItem;


### PR DESCRIPTION
When changing the permissions of a Page item, the update should be propagated to its subsequent children Page items.

For example, updating the permission of a high-level Page item should propagate the update to its children to maintain consistency of access control.
