### PR TITLE
Files added public by default regardless of Page permissions FIST-517  #resolve

### DIFF
--- a/fenixedu-ist-cms-components/src/main/java/pt/ist/fenixedu/cmscomponents/ui/spring/PagesAdminService.java
+++ b/fenixedu-ist-cms-components/src/main/java/pt/ist/fenixedu/cmscomponents/ui/spring/PagesAdminService.java
@@ -182,7 +182,7 @@ public class PagesAdminService {
     protected PostFile addAttachment(String name, MultipartFile attachment, MenuItem menuItem) throws IOException {
         Post post = postForPage(menuItem.getPage());
         GroupBasedFile file =
-                new GroupBasedFile(name, attachment.getOriginalFilename(), attachment.getBytes(), Group.anyone());
+                new GroupBasedFile(name, attachment.getOriginalFilename(), attachment.getBytes(), post.getCanViewGroup());
         return new PostFile(post, file, false, post.getFilesSet().size());
     }
 


### PR DESCRIPTION
When adding a file to a Page, the access control is "public" by default, which may go against the access control of the Page.

The access control of the Page should be used instead.