### PR TITLE
Fix delegate list functionality to be used by anyone FIST-527 #resolve

### DIFF
--- a/fenixedu-ist-delegates/src/main/java/pt/ist/fenixedu/delegates/ui/DelegatesController.java
+++ b/fenixedu-ist-delegates/src/main/java/pt/ist/fenixedu/delegates/ui/DelegatesController.java
@@ -51,7 +51,7 @@ public class DelegatesController {
                 degree = student.getLastActiveRegistration().getDegree();
             }
             if (degree == null && student.getLastRegistration() != null) {
-                degree = student.getLastActiveRegistration().getDegree();
+                degree = student.getLastRegistration().getDegree();
             }
         }
         delegateSearchBean.setDegree(degree);

--- a/fenixedu-ist-delegates/src/main/webapp/WEB-INF/delegates/search.jsp
+++ b/fenixedu-ist-delegates/src/main/webapp/WEB-INF/delegates/search.jsp
@@ -64,7 +64,7 @@
 	<div class="form-group">
 		<label for="degree" class="col-md-1 control-label"><spring:message code="label.delegates.select.degree.sel"/></label>
 		<div class="col-md-11">
-			<form:select path="degree" items="${searchBean.degrees}" itemLabel="nameI18N" itemValue="externalId" onchange="onchangeDegree(); submit();" class="form-control"/>
+			<form:select path="degree" items="${searchBean.degrees}" itemLabel="nameI18N.content" itemValue="externalId" onchange="onchangeDegree(); submit();" class="form-control"/>
 		</div>
 	</div>
 </form:form>


### PR DESCRIPTION
Regarding the portal configuration, make sure the "Delegates" functionality is removed from the "Student" section when the migration is done.