### PR TITLE
Use jackson-core dependency version from academic for consistency FIST-663 #resolve

### DIFF
--- a/fenixedu-ist-integration/pom.xml
+++ b/fenixedu-ist-integration/pom.xml
@@ -12,9 +12,7 @@
     <name>FenixEdu IST Integration</name>
 
     <properties>
-        <version.com.fasterxml.jackson.core.jackson-annotations>2.8.11</version.com.fasterxml.jackson.core.jackson-annotations>
-        <version.com.fasterxml.jackson.core.jackson-databind>2.8.11</version.com.fasterxml.jackson.core.jackson-databind>
-        <version.com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider>2.8.11</version.com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider>
+        <version.com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider>2.9.7</version.com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider>
         <version.com.googlecode.json-simple.json-simple>1.1.1</version.com.googlecode.json-simple.json-simple>
         <version.org.mnode.ical4j.ical4j>2.0.0</version.org.mnode.ical4j.ical4j>
         <version.pt.ist.renates-integration>1.0.0</version.pt.ist.renates-integration>
@@ -151,16 +149,6 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${version.com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${version.com.fasterxml.jackson.core.jackson-annotations}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
         </dependency>
         <dependency>
             <groupId>org.mnode.ical4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <inceptionYear>2013</inceptionYear>
 
     <properties>
-        <version.org.fenixedu.academic>18.6.0</version.org.fenixedu.academic>
+        <version.org.fenixedu.academic>18.6.1</version.org.fenixedu.academic>
         <version.com.google.code.gson.gson>2.8.0</version.com.google.code.gson.gson>
         <version.com.google.guava.guava>27.0-jre</version.com.google.guava.guava>
         <version.com.lowagie.itext>2.1.0</version.com.lowagie.itext>


### PR DESCRIPTION
**Fix SNAPSHOT version to latest academic release before merging**

- Also bumped jackson-jaxrs to 2.9.7