### PR TITLE
Prevent future ExecutionYears from showing on delegate messaging FIST-973 #resolve

### DIFF
--- a/fenixedu-ist-delegates/src/main/java/pt/ist/fenixedu/delegates/domain/student/Delegate.java
+++ b/fenixedu-ist-delegates/src/main/java/pt/ist/fenixedu/delegates/domain/student/Delegate.java
@@ -18,7 +18,6 @@
  */
 package pt.ist.fenixedu.delegates.domain.student;
 
-import org.fenixedu.academic.domain.CurricularCourse;
 import org.fenixedu.academic.domain.CurricularYear;
 import org.fenixedu.academic.domain.ExecutionCourse;
 import org.fenixedu.academic.domain.ExecutionYear;
@@ -31,6 +30,7 @@ import org.joda.time.Interval;
 import pt.ist.fenixedu.delegates.ui.DelegateBean;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class Delegate extends Delegate_Base {
 
@@ -71,7 +71,10 @@ public abstract class Delegate extends Delegate_Base {
     public List<ExecutionYear> getMandateExecutionYears() {
         final ExecutionYear start = ExecutionYear.readByDateTime(getStart());
         final ExecutionYear end = ExecutionYear.readByDateTime(getEnd());
-        return ExecutionYear.readExecutionYears(start, end);
+        return ExecutionYear.readExecutionYears(start, end)
+                .stream()
+                .filter(executionYear -> executionYear.isBeforeOrEquals(ExecutionYear.readCurrentExecutionYear()))
+                .collect(Collectors.toList());
     }
 
     public Registration getRegistration() {

--- a/fenixedu-ist-delegates/src/main/java/pt/ist/fenixedu/delegates/ui/DelegateStudentSelectBean.java
+++ b/fenixedu-ist-delegates/src/main/java/pt/ist/fenixedu/delegates/ui/DelegateStudentSelectBean.java
@@ -134,7 +134,9 @@ public class DelegateStudentSelectBean {
             }
         }
         if (!CollectionUtils.isEmpty(selectedGroupsExecutionYears)) {
+            final List<ExecutionYear> mandateExecutionYears = selectedPosition.getMandateExecutionYears();
             selectedGroupsExecutionYears.stream()
+                    .filter(mandateExecutionYears::contains)
                     .map(selectedPosition::getStudentGroupForExecutionYear)
                     .forEach(toRet::add);
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7467891/157021781-7f4a5567-bf02-4b24-b792-2161ade2e9c1.png)

After:
![image](https://user-images.githubusercontent.com/7467891/157021818-84a9cfa2-c144-498e-92fd-7c57de295dda.png)

Also fix a security exploit where a delegate could change the External ID of the ExecutionYear in the checkbox to send an email to any ExecutionYear.