### PR TITLE
Fix wrong day in interval on spaces API for multiday events FIST-978 #resolve

### DIFF
--- a/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/api/FenixAPIv1.java
+++ b/fenixedu-ist-integration/src/main/java/pt/ist/fenixedu/integration/api/FenixAPIv1.java
@@ -2116,9 +2116,8 @@ public class FenixAPIv1 {
         try {
             for (Object occupation : bodyComponent.getInfoShowOccupation()) {
                 InfoShowOccupation showOccupation = (InfoShowOccupation) occupation;
-                DateTime date = new DateTime(rightNow);
-                DateTime newDate = date.withDayOfWeek(showOccupation.getDiaSemana().getDiaSemanaInDayOfWeekJodaFormat());
-                String day = formatDay.print(newDate);
+                String dayStart = formatDay.print(showOccupation.getInicio().getTimeInMillis());
+                String dayEnd = formatDay.print(showOccupation.getFim().getTimeInMillis());
 
                 FenixRoomEvent roomEvent = null;
 
@@ -2130,13 +2129,13 @@ public class FenixAPIv1 {
                     String end = formatHour.print(lesson.getFim().getTimeInMillis());
                     String weekday = lesson.getDiaSemana().getDiaSemanaString();
 
-                    FenixPeriod period = new FenixPeriod(day + " " + start, day + " " + end);
+                    FenixPeriod period = new FenixPeriod(dayStart + " " + start, dayEnd + " " + end);
 
                     String info = lesson.getInfoShift().getShiftTypesCodePrettyPrint();
 
                     FenixCourse course = new FenixCourse(infoExecutionCourse.getExecutionCourse());
 
-                    roomEvent = new FenixRoomEvent.LessonEvent(start, end, weekday, day, period, info, course);
+                    roomEvent = new FenixRoomEvent.LessonEvent(start, end, weekday, dayStart, period, info, course);
 
                 } else if (showOccupation instanceof InfoWrittenEvaluation) {
                     InfoWrittenEvaluation infoWrittenEvaluation = (InfoWrittenEvaluation) showOccupation;
@@ -2158,12 +2157,12 @@ public class FenixAPIv1 {
                         end = infoExam.getEndHour();
                         weekday = infoWrittenEvaluation.getDiaSemana().getDiaSemanaString();
 
-                        FenixPeriod period = new FenixPeriod(day + " " + start, day + " " + end);
+                        FenixPeriod period = new FenixPeriod(dayStart + " " + start, dayEnd + " " + end);
 
                         Integer season = infoExam.getSeason().getSeason();
 
                         roomEvent =
-                                new FenixRoomEvent.WrittenEvaluationEvent.ExamEvent(start, end, weekday, day, period, courses,
+                                new FenixRoomEvent.WrittenEvaluationEvent.ExamEvent(start, end, weekday, dayStart, period, courses,
                                         season);
 
                     } else if (infoWrittenEvaluation instanceof InfoWrittenTest) {
@@ -2173,10 +2172,10 @@ public class FenixAPIv1 {
                         end = formatHour.print(infoWrittenTest.getFim().getTimeInMillis());
                         weekday = infoWrittenTest.getDiaSemana().getDiaSemanaString();
 
-                        FenixPeriod period = new FenixPeriod(day + " " + start, day + " " + end);
+                        FenixPeriod period = new FenixPeriod(dayStart + " " + start, dayEnd + " " + end);
 
                         roomEvent =
-                                new FenixRoomEvent.WrittenEvaluationEvent.TestEvent(start, end, weekday, day, period, courses,
+                                new FenixRoomEvent.WrittenEvaluationEvent.TestEvent(start, end, weekday, dayStart, period, courses,
                                         description);
                     }
 
@@ -2188,9 +2187,9 @@ public class FenixAPIv1 {
                     String start = formatHour.print(infoGenericEvent.getInicio().getTimeInMillis());
                     String end = formatHour.print(infoGenericEvent.getFim().getTimeInMillis());
                     String weekday = infoGenericEvent.getDiaSemana().getDiaSemanaString();
-                    FenixPeriod period = new FenixPeriod(day + " " + start, day + " " + end);
+                    FenixPeriod period = new FenixPeriod(dayStart + " " + start, dayEnd + " " + end);
 
-                    roomEvent = new FenixRoomEvent.GenericEvent(start, end, weekday, day, period, description, title);
+                    roomEvent = new FenixRoomEvent.GenericEvent(start, end, weekday, dayStart, period, description, title);
                 }
 
                 if (roomEvent != null) {


### PR DESCRIPTION
End date on interval always showed the first day instead of the last day

Before:
![image](https://user-images.githubusercontent.com/7467891/169346581-95aec147-3028-4cd7-a652-1d1d905a5e2c.png)

After:
![image](https://user-images.githubusercontent.com/7467891/169346652-c758fb0a-5d4a-4005-b5a4-2a32c6fb4a07.png)

(the hours are not the same since it's not the same event, but gets the point across)